### PR TITLE
1、【移除】对于项目对于 `defined(SFUD_USING_SFDP) && defined(SFUD_USING_FLASH_IN…

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,25 @@
 
 #### 2.2.1 初始化 SFUD 库
 
+将会调用 `sfud_device_init` ，初始化 Flash 设备表中的全部设备。如果只有一个 Flash 也可以只使用 `sfud_device_init` 进行单一初始化。
+
 > 注意：初始化完的 SPI Flash 默认都 **已取消写保护** 状态，如需开启写保护，请使用 sfud_write_status 函数修改 SPI Flash 状态。
 
 ```C
 sfud_err sfud_init(void)
 ```
 
-#### 2.2.2 获取 Flash 设备对象
+#### 2.2.2 初始化指定的 Flash 设备
+
+```C
+sfud_err sfud_device_init(sfud_flash *flash)
+```
+
+|参数                                    |描述|
+|:-----                                  |:----|
+|flash                                   |待初始化的 Flash 设备|
+
+#### 2.2.3 获取 Flash 设备对象
 
 在 SFUD 配置文件中会定义 Flash 设备表，负责存放所有将要使用的 Flash 设备对象，所以 SFUD 支持多个 Flash 设备同时驱动。设备表的配置在 `/sfud/inc/sfud_cfg.h` 中 `SFUD_FLASH_DEVICE_TABLE` 宏定义，详细配置方法参照 [2.3 配置方法 Flash](#23-配置方法)）。本方法通过 Flash 设备位于设备表中索引值来返回 Flash 设备对象，超出设备表范围返回 `NULL` 。
 
@@ -78,21 +90,7 @@ sfud_flash *sfud_get_device(size_t index)
 |:-----                                  |:----|
 |index                                   |Flash 设备位于 FLash 设备表中的索引值|
 
-#### 2.2.3 获取 Flash 设备总数
-
-返回 Flash 设备表的总长度。
-
-```C
-size_t sfud_get_device_num(void)
-```
-
-#### 2.2.4 获取 Flash 设备表
-
-```C
-const sfud_flash *sfud_get_device_table(void)
-```
-
-#### 2.2.5 读取 Flash 数据
+#### 2.2.4 读取 Flash 数据
 
 ```C
 sfud_err sfud_read(const sfud_flash *flash, uint32_t addr, size_t size, uint8_t *data)
@@ -105,7 +103,7 @@ sfud_err sfud_read(const sfud_flash *flash, uint32_t addr, size_t size, uint8_t 
 |size                                    |从起始地址开始读取数据的总大小|
 |data                                    |读取到的数据|
 
-#### 2.2.6 擦除 Flash 数据
+#### 2.2.5 擦除 Flash 数据
 
 > 注意：擦除操作将会按照 Flash 芯片的擦除粒度（详见 Flash 数据手册，一般为 block 大小。初始化完成后，可以通过 `sfud_flash->chip.erase_gran` 查看）对齐，请注意保证起始地址和擦除数据大小按照 Flash 芯片的擦除粒度对齐，否则执行擦除操作后，将会导致其他数据丢失。
 
@@ -119,7 +117,7 @@ sfud_err sfud_erase(const sfud_flash *flash, uint32_t addr, size_t size)
 |addr                                    |起始地址|
 |size                                    |从起始地址开始擦除数据的总大小|
 
-#### 2.2.7 擦除 Flash 全部数据
+#### 2.2.6 擦除 Flash 全部数据
 
 ```C
 sfud_err sfud_chip_erase(const sfud_flash *flash)
@@ -129,7 +127,7 @@ sfud_err sfud_chip_erase(const sfud_flash *flash)
 |:-----                                  |:----|
 |flash                                   |Flash 设备对象|
 
-#### 2.2.8 往 Flash 写数据
+#### 2.2.7 往 Flash 写数据
 
 ```C
 sfud_err sfud_write(const sfud_flash *flash, uint32_t addr, size_t size, const uint8_t *data)
@@ -142,7 +140,7 @@ sfud_err sfud_write(const sfud_flash *flash, uint32_t addr, size_t size, const u
 |size                                    |从起始地址开始写入数据的总大小|
 |data                                    |待写入的数据|
 
-#### 2.2.9 先擦除再往 Flash 写数据
+#### 2.2.8 先擦除再往 Flash 写数据
 
 > 注意：擦除操作将会按照 Flash 芯片的擦除粒度（详见 Flash 数据手册，一般为 block 大小。初始化完成后，可以通过 `sfud_flash->chip.erase_gran` 查看）对齐，请注意保证起始地址和擦除数据大小按照 Flash 芯片的擦除粒度对齐，否则执行擦除操作后，将会导致其他数据丢失。
 
@@ -157,7 +155,7 @@ sfud_err sfud_erase_write(const sfud_flash *flash, uint32_t addr, size_t size, c
 |size                                    |从起始地址开始写入数据的总大小|
 |data                                    |待写入的数据|
 
-#### 2.2.10 读取 Flash 状态
+#### 2.2.9 读取 Flash 状态
 
 ```C
 sfud_err sfud_read_status(const sfud_flash *flash, uint8_t *status)
@@ -168,7 +166,7 @@ sfud_err sfud_read_status(const sfud_flash *flash, uint8_t *status)
 |flash                                   |Flash 设备对象|
 |status                                  |当前状态寄存器值|
 
-#### 2.2.11 写（修改） Flash 状态
+#### 2.2.10 写（修改） Flash 状态
 
 ```C
 sfud_err sfud_write_status(const sfud_flash *flash, bool is_volatile, uint8_t status)
@@ -200,9 +198,25 @@ sfud_err sfud_write_status(const sfud_flash *flash, bool is_volatile, uint8_t st
 
 > 注意：关闭后该库只驱动支持 SFDP 规范的 Flash，也会适当的降低部分代码量。另外 2.3.2 及 2.3.3 这两个宏定义至少定义一种，也可以两种方式都选择。
 
-#### 2.3.4 Flash 设备表
+#### 2.3.4 既不使用 SFDP ，也不使用 Flash 参数信息表
 
-主要修改 `SFUD_FLASH_DEVICE_TABLE` 这个宏定义，示例如下：
+为了进一步降低代码量，`SFUD_USING_SFDP` 与 `SFUD_USING_FLASH_INFO_TABLE` 也可以 **都不定义** 。
+
+此时，只要在定义 Flash 设备时，指定好 Flash 参数，之后再调用 `sfud_device_init` 对该设备进行初始化。参考如下代码：
+
+```C
+sfud_flash sfud_norflash0 = {
+        .name = "norflash0",
+        .spi.name = "SPI1",
+        .chip = { "W25Q64FV", SFUD_MF_ID_WINBOND, 0x40, 0x17, 8L * 1024L * 1024L, SFUD_WM_PAGE_256B, 4096, 0x20 } };
+......
+sfud_device_init(&sfud_norflash0);
+......
+```
+
+#### 2.3.5 Flash 设备表
+
+如果产品中存在多个 Flash ，可以添加 Flash 设备表。修改 `SFUD_FLASH_DEVICE_TABLE` 这个宏定义，示例如下：
 
 ```C
 enum {

--- a/sfud/inc/sfud.h
+++ b/sfud/inc/sfud.h
@@ -44,6 +44,15 @@ extern "C" {
 sfud_err sfud_init(void);
 
 /**
+ * SFUD initialize by flash device
+ *
+ * @param flash flash device
+ *
+ * @return result
+ */
+sfud_err sfud_device_init(sfud_flash *flash);
+
+/**
  * get flash device by its index which in the flash information table
  *
  * @param index the index which in the flash information table  @see flash_table

--- a/sfud/inc/sfud_def.h
+++ b/sfud/inc/sfud_def.h
@@ -77,7 +77,7 @@ if (!(EXPR))                                                                   \
     else {if (__delay_temp) {__delay_temp();} retry --;}
 
 /* software version number */
-#define SFUD_SW_VERSION                             "1.0.3"
+#define SFUD_SW_VERSION                             "1.0.4"
 /*
  * all defined supported command
  */

--- a/sfud/src/sfud.c
+++ b/sfud/src/sfud.c
@@ -36,10 +36,6 @@
 #error "Please configure the flash device information table in (in sfud_cfg.h)."
 #endif
 
-#if !defined(SFUD_USING_SFDP) && !defined(SFUD_USING_FLASH_INFO_TABLE)
-#error "Please configure SFUD_USING_SFDP or SFUD_USING_FLASH_INFO_TABLE at least one kind of mode (in sfud_cfg.h)."
-#endif
-
 /* user configured flash device information table */
 static sfud_flash flash_table[] = SFUD_FLASH_DEVICE_TABLE;
 /* supported manufacturer information table */
@@ -401,7 +397,7 @@ sfud_err sfud_erase(const sfud_flash *flash, uint32_t addr, size_t size) {
     sfud_err result = SFUD_SUCCESS;
     const sfud_spi *spi = &flash->spi;
     uint8_t cmd_data[5], cmd_size, cur_erase_cmd;
-    size_t eraser_index, cur_erase_size;
+    size_t cur_erase_size;
 
     SFUD_ASSERT(flash);
     /* must be call this function after initialize OK */
@@ -425,6 +421,7 @@ sfud_err sfud_erase(const sfud_flash *flash, uint32_t addr, size_t size) {
     while (size) {
         /* if this flash is support SFDP parameter, then used SFDP parameter supplies eraser */
 #ifdef SFUD_USING_SFDP
+        size_t eraser_index;
         if (flash->sfdp.available) {
             /* get the suitable eraser for erase process from SFDP parameter */
             eraser_index = sfud_sfdp_get_suitable_eraser(flash, addr, size);


### PR DESCRIPTION
…FO_TABLE` 的依赖。如果不定义这两个宏时，可以手动在 flash 设备中指定 chip 信息，再调用 sfud_device_init 初始化设备，进一步降低资源占用。

Signed-off-by: armink <armink.ztl@gmail.com>